### PR TITLE
Add git so bundle audit clones the advisory repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:2.7.0-alpine
 COPY LICENSE README.md /
 COPY entrypoint.sh /entrypoint.sh
 
+RUN apk add git
 RUN gem install bundler bundler-audit
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Hidden in https://github.com/rubysec/bundler-audit/blob/master/lib/bundler/audit/database.rb#L101-L119 bundler-audit is shelling out to use `git` binary. If it doesn't exist then we get the error message "Skipping update" logged from `bundle-audit update`.

Install git inside the docker image so bundler audit can grab the latest advisory database for us.